### PR TITLE
Support `mix compile` Output as Input

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Now run fix_warnings.
 
 ```
 mix fix_warnings -f path/to/output.log
+# or
+mix fix_warnings --file=path/to/output.log
 ```
 
 Enjoy

--- a/README.md
+++ b/README.md
@@ -64,3 +64,6 @@ git diff
 - Add more warnings
 - Refactor mix task
 - Does not seem to capture warnings in `.exs` files
+- Add support for `preview` flag
+  - this should be the default, so maybe add support for `force` flag?
+- Add diffing output

--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ git diff
 - There might be a few edge-cases
 - Add more warnings
 - Refactor mix task
+- Does not seem to capture warnings in `.exs` files

--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ FixWarnings automatically fixes the trivial warnings directly in your Elixir sou
 
 I extracted this from a quickly hacked together script, which worked well for me. But don't trust this blindly yet, verify with git diff first.
 
-Limitations:
-- You have to manually copy the log output that contains the warnings into a file
-
 ## Guide
 
 Add `fix_warnings` to your mix.exs.
@@ -42,27 +39,17 @@ Install dependency
 mix deps.get
 ```
 
-Clean your files so that everything is compiled from scratch:
-
+Run fix_warnings:
 ```
-mix clean
-```
-
-Run your Elixir. E.g. for a phoenix application:
-
-```
-clear # empty the console window, so we can copy the ouptut.
-mix
+mix fix_warnings
 ```
 
-Manually copy (as in Cmd+a, Cmd+c, Cmd+v) the console output that contains all the warnings into a file (Note to myself: there must be multiple better ways to achieve this).
-
-Now run fix_warnings.
-
+Or run with explicitly captured logs:
 ```
+mix compile --force &> path/to/output.log
+
 mix fix_warnings -f path/to/output.log
-# or
-mix fix_warnings --file=path/to/output.log
+# or mix fix_warnings --file=path/to/output.log
 ```
 
 Enjoy
@@ -74,6 +61,5 @@ git diff
 ## TODOs (PRs welcome)
 
 - There might be a few edge-cases
-- Find a way so fix_warnings can tap into STDERR directly, so we don't have to mess with around copying console output to files.
 - Add more warnings
 - Refactor mix task

--- a/lib/fix_warnings.ex
+++ b/lib/fix_warnings.ex
@@ -29,12 +29,12 @@ defmodule FixWarnings do
     ]
   end
 
-  def run(args, mode \\ :preview) do
+  def run(args, _mode \\ :preview) do
     # IO.puts("parsing log: #{path}")
 
     args
     |> changes()
-    |> Enum.filter(fn {path, content} -> File.exists?(path) end)
+    |> Enum.filter(fn {path, _content} -> File.exists?(path) end)
     |> Enum.each(fn {path, content} ->
       # IO.puts("- writing #{path}")
       File.write(path, content)

--- a/lib/log_parser.ex
+++ b/lib/log_parser.ex
@@ -23,7 +23,7 @@ defmodule FixWarnings.LogParser do
         d.match?(curr_line)
       end)
 
-    fixes =
+    _fixes =
       if definition do
         case definition.build(curr_line, tail) do
           {:ok, fix, tail} ->

--- a/lib/log_parser.ex
+++ b/lib/log_parser.ex
@@ -16,22 +16,25 @@ defmodule FixWarnings.LogParser do
   end
 
   defp parse_lines(fixes, []), do: fixes
+
   defp parse_lines(fixes, [curr_line | tail]) do
-    definition = Enum.find(FixWarnings.enabled_patches, fn(d) ->
-      d.match?(curr_line)
-    end)
+    definition =
+      Enum.find(FixWarnings.enabled_patches(), fn d ->
+        d.match?(curr_line)
+      end)
 
-    fixes = if definition do
-      case definition.build(curr_line, tail) do
-        {:ok, fix, tail} ->
-          parse_lines([fix | fixes], tail)
-        _ ->
-          # log: warning
-          parse_lines(fixes, tail)
+    fixes =
+      if definition do
+        case definition.build(curr_line, tail) do
+          {:ok, fix, tail} ->
+            parse_lines([fix | fixes], tail)
+
+          _ ->
+            # log: warning
+            parse_lines(fixes, tail)
+        end
+      else
+        parse_lines(fixes, tail)
       end
-    else
-      parse_lines(fixes, tail)
-    end
   end
-
 end

--- a/lib/log_reader.ex
+++ b/lib/log_reader.ex
@@ -1,0 +1,24 @@
+defmodule FixWarnings.LogReader do
+  def read_from_file!(nil) do
+    raise "Error: Please provide path. Example\n. mix fix_warnings -f path/to/output.log"
+  end
+
+  def read_from_file!(path) do
+    if File.exists?(path) do
+      File.read!(path)
+    else
+      raise "Error: file #{path} does not exists. "
+    end
+  end
+
+  def read_from_output! do
+    System.cmd("mix", ~w/clean/)
+
+    IO.puts("🧪")
+
+    {output, _exit_status} =
+      System.cmd("mix", ~w/compile --force/, stderr_to_stdout: true) |> IO.inspect(label: "cmd")
+
+    output
+  end
+end

--- a/lib/log_reader.ex
+++ b/lib/log_reader.ex
@@ -14,10 +14,7 @@ defmodule FixWarnings.LogReader do
   def read_from_output! do
     System.cmd("mix", ~w/clean/)
 
-    IO.puts("🧪")
-
-    {output, _exit_status} =
-      System.cmd("mix", ~w/compile --force/, stderr_to_stdout: true) |> IO.inspect(label: "cmd")
+    {output, _exit_status} = System.cmd("mix", ~w/compile --force/, stderr_to_stdout: true)
 
     output
   end

--- a/lib/mix/tasks/fix_warnings.ex
+++ b/lib/mix/tasks/fix_warnings.ex
@@ -28,16 +28,6 @@ defmodule Mix.Tasks.FixWarnings do
 
     args = Map.new(args)
 
-    path = args[:file]
-
-    if is_nil(path) do
-      raise "Error: Please provide path. Example\n. mix fix_warnings -f path/to/output.log"
-    end
-
-    if !File.exists?(path) do
-      raise "Error: file #{args[:file]} does not exists. "
-    end
-
     answer =
       if args[:quiet] do
         "y"
@@ -52,7 +42,7 @@ defmodule Mix.Tasks.FixWarnings do
       end
 
     if answer == "y" do
-      FixWarnings.run(path)
+      FixWarnings.run(args)
     else
       IO.puts("Cancelled")
     end

--- a/lib/mix/tasks/fix_warnings.ex
+++ b/lib/mix/tasks/fix_warnings.ex
@@ -20,33 +20,36 @@ defmodule Mix.Tasks.FixWarnings do
 
   @doc false
   def run(args) do
-    {_,_,args} =  OptionParser.parse(args)
+    {_, _, args} = OptionParser.parse(args)
     args = Map.new(args)
 
     path = args["-f"]
+
     if is_nil(path) do
       raise "Error: Please provide path. Example\n. mix fix_warnings -f path/to/output.log"
     end
+
     if !File.exists?(path) do
       raise "Error: file #{args["-f"]} does not exists. "
     end
 
-    answer = if Enum.member?(args, "-q") || Enum.member?(args, "--quiet") do
-      "y"
-    else
-      IO.puts "\n\n"
-      IO.puts "Warning: This will **overwrite** your source code.\n"
-      IO.puts "Are you sure? [Yn]:"
+    answer =
+      if Enum.member?(args, "-q") || Enum.member?(args, "--quiet") do
+        "y"
+      else
+        IO.puts("\n\n")
+        IO.puts("Warning: This will **overwrite** your source code.\n")
+        IO.puts("Are you sure? [Yn]:")
 
-      IO.read(:stdio, :line)
-      |> String.trim
-      |> String.downcase
-    end
+        IO.read(:stdio, :line)
+        |> String.trim()
+        |> String.downcase()
+      end
 
-    if answer == "y"  do
+    if answer == "y" do
       FixWarnings.run(path)
     else
-      IO.puts "Cancelled"
+      IO.puts("Cancelled")
     end
   end
 end

--- a/lib/mix/tasks/fix_warnings.ex
+++ b/lib/mix/tasks/fix_warnings.ex
@@ -20,21 +20,26 @@ defmodule Mix.Tasks.FixWarnings do
 
   @doc false
   def run(args) do
-    {_, _, args} = OptionParser.parse(args)
+    {args, _, _} =
+      OptionParser.parse(args,
+        aliases: [q: :quiet],
+        strict: [file: :string, quiet: :boolean]
+      )
+
     args = Map.new(args)
 
-    path = args["-f"]
+    path = args[:f]
 
     if is_nil(path) do
       raise "Error: Please provide path. Example\n. mix fix_warnings -f path/to/output.log"
     end
 
     if !File.exists?(path) do
-      raise "Error: file #{args["-f"]} does not exists. "
+      raise "Error: file #{args[:f]} does not exists. "
     end
 
     answer =
-      if Enum.member?(args, "-q") || Enum.member?(args, "--quiet") do
+      if args[:quiet] do
         "y"
       else
         IO.puts("\n\n")

--- a/lib/mix/tasks/fix_warnings.ex
+++ b/lib/mix/tasks/fix_warnings.ex
@@ -22,20 +22,20 @@ defmodule Mix.Tasks.FixWarnings do
   def run(args) do
     {args, _, _} =
       OptionParser.parse(args,
-        aliases: [q: :quiet],
+        aliases: [f: :file, q: :quiet],
         strict: [file: :string, quiet: :boolean]
       )
 
     args = Map.new(args)
 
-    path = args[:f]
+    path = args[:file]
 
     if is_nil(path) do
       raise "Error: Please provide path. Example\n. mix fix_warnings -f path/to/output.log"
     end
 
     if !File.exists?(path) do
-      raise "Error: file #{args[:f]} does not exists. "
+      raise "Error: file #{args[:file]} does not exists. "
     end
 
     answer =

--- a/lib/patch/unused_alias.ex
+++ b/lib/patch/unused_alias.ex
@@ -28,7 +28,7 @@ defmodule FixWarnings.Patch.UnusedAlias do
     !is_nil(alias_name(line))
   end
 
-  def build(curr_line, []), do: {:error}
+  def build(_curr_line, []), do: {:error}
 
   def build(curr_line, tail) do
     [file_loc | tail] = tail

--- a/lib/patch/unused_alias.ex
+++ b/lib/patch/unused_alias.ex
@@ -29,6 +29,7 @@ defmodule FixWarnings.Patch.UnusedAlias do
   end
 
   def build(curr_line, []), do: {:error}
+
   def build(curr_line, tail) do
     [file_loc | tail] = tail
 
@@ -36,6 +37,7 @@ defmodule FixWarnings.Patch.UnusedAlias do
       {path, no} ->
         fix = %UnusedAlias{path: path, line: no, element: alias_name(curr_line)}
         {:ok, fix, tail}
+
       _ ->
         {:error}
     end
@@ -48,7 +50,8 @@ defmodule FixWarnings.Patch.UnusedAlias do
       ~r/(\W)(#{el}\W)/
       |> Regex.replace(line, "\\g{1}")
     else
-      nil # remove this line
+      # remove this line
+      nil
     end
   end
 

--- a/lib/patch/unused_variable.ex
+++ b/lib/patch/unused_variable.ex
@@ -29,7 +29,7 @@ defmodule FixWarnings.Patch.UnusedVariable do
     !is_nil(element_name(line))
   end
 
-  def build(curr_line, []), do: {:error}
+  def build(_curr_line, []), do: {:error}
 
   def build(curr_line, tail) do
     [file_loc | tail] = tail

--- a/lib/patch/unused_variable.ex
+++ b/lib/patch/unused_variable.ex
@@ -30,6 +30,7 @@ defmodule FixWarnings.Patch.UnusedVariable do
   end
 
   def build(curr_line, []), do: {:error}
+
   def build(curr_line, tail) do
     [file_loc | tail] = tail
 
@@ -37,6 +38,7 @@ defmodule FixWarnings.Patch.UnusedVariable do
       {path, no} ->
         fix = %UnusedVariable{path: path, line: no, element: element_name(curr_line)}
         {:ok, fix, tail}
+
       _ ->
         {:error}
     end

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -8,7 +8,7 @@ defmodule FixWarnings.Util do
           {line_number, _} ->
             {path, line_number}
 
-          e ->
+          _e ->
             # TODO: check why it doesnt match
             nil
         end

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -5,12 +5,16 @@ defmodule FixWarnings.Util do
     case Regex.scan(@source_matcher, line) do
       [[_, path, line_number]] ->
         case Integer.parse(line_number) do
-          {line_number, _} -> {path, line_number}
+          {line_number, _} ->
+            {path, line_number}
+
           e ->
             # TODO: check why it doesnt match
             nil
         end
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
 

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -1,5 +1,5 @@
 defmodule FixWarnings.Util do
-  @source_matcher ~r/  (.*):(\d*)/
+  @source_matcher ~r/  (.*):(\d*)(?::|\z)/m
 
   def parse_source(line) do
     case Regex.scan(@source_matcher, line) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,25 +4,28 @@ defmodule FixWarnings.Mixfile do
   @version "0.1.3"
 
   def project do
-    [app: :fix_warnings,
-     version: @version,
-     elixir: "~> 1.4",
-     description: "A mix task that automatically fixes compiler warnings in your Elixir project",
-     package: [
-      licenses: "MIT",
-      maintainers: ["hasclass"],
-      licenses: ["MIT"],
-      links: %{github: "https://github.com/hasclass/fix_warnings"},
-      files: ~w(lib) ++
-        ~w(LICENSE.md mix.exs README.md)
-     ],
-    docs: [
-      source_ref: "v#{@version}",
-      main: "Mix.Tasks.FixWarnings"
-    ],
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps()]
+    [
+      app: :fix_warnings,
+      version: @version,
+      elixir: "~> 1.4",
+      description: "A mix task that automatically fixes compiler warnings in your Elixir project",
+      package: [
+        licenses: "MIT",
+        maintainers: ["hasclass"],
+        licenses: ["MIT"],
+        links: %{github: "https://github.com/hasclass/fix_warnings"},
+        files:
+          ~w(lib) ++
+            ~w(LICENSE.md mix.exs README.md)
+      ],
+      docs: [
+        source_ref: "v#{@version}",
+        main: "Mix.Tasks.FixWarnings"
+      ],
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application
@@ -44,7 +47,7 @@ defmodule FixWarnings.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:ex_doc, "~> 0.16", only: :dev},
+      {:ex_doc, "~> 0.16", only: :dev}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,9 @@
-%{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+%{
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm", "59514c4a207f9f25c5252e09974367718554b6a0f41fe39f7dc232168f9cb309"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.29", "149d50dcb3a93d9f3d6f3ecf18c918fb5a2d3c001b5d3305c926cddfbd33355b", [:mix], [], "hexpm", "4902af1b3eb139016aed210888748db8070b8125c2342ce3dcae4f38dcc63503"},
+  "ex_doc": {:hex, :ex_doc, "0.29.1", "b1c652fa5f92ee9cf15c75271168027f92039b3877094290a75abcaac82a9f77", [:mix], [{:earmark_parser, "~> 1.4.19", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "b7745fa6374a36daf484e2a2012274950e084815b936b1319aeebcf7809574f6"},
+  "makeup": {:hex, :makeup, "1.1.0", "6b67c8bc2882a6b6a445859952a602afc1a41c2e08379ca057c0f525366fc3ca", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "0a45ed501f4a8897f580eabf99a2e5234ea3e75a4373c8a52824f6e873be57a6"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.16.0", "f8c570a0d33f8039513fbccaf7108c5d750f47d8defd44088371191b76492b0b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "28b2cbdc13960a46ae9a8858c4bebdec3c9a6d7b4b9e7f4ed1502f8159f338e7"},
+  "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
+}

--- a/test/fix_warnings_test.exs
+++ b/test/fix_warnings_test.exs
@@ -1,6 +1,4 @@
-
 require IEx
-
 
 defmodule FixWarningsTest do
   use ExUnit.Case
@@ -9,45 +7,47 @@ defmodule FixWarningsTest do
   test "basic test" do
     changes = FixWarnings.changes("test/test.log")
 
-    assert String.trim(changes["examples/foo.ex"]) == String.trim("""
-defmodule Examples.Bar do
-end
+    assert String.trim(changes["examples/foo.ex"]) ==
+             String.trim("""
+             defmodule Examples.Bar do
+             end
 
-defmodule Examples.Foo do
-  alias String
+             defmodule Examples.Foo do
+               alias String
 
-  def foo(_unused_param) do
-    String.length("hello")
-  end
+               def foo(_unused_param) do
+                 String.length("hello")
+               end
 
-  def foo(_unused_param1, _unused_param2) do
-  end
-end
-""")
+               def foo(_unused_param1, _unused_param2) do
+               end
+             end
+             """)
   end
 
   test "edge-cases" do
     changes = FixWarnings.changes("test/todo.log")
 
-    assert String.trim(changes["examples/todo.ex"]) == String.trim("""
-defmodule Examples.Bar do
-end
-defmodule Examples.Baz do
-end
+    assert String.trim(changes["examples/todo.ex"]) ==
+             String.trim("""
+             defmodule Examples.Bar do
+             end
+             defmodule Examples.Baz do
+             end
 
-defmodule Examples.AliasWithCurlyBrackets do
-  alias Examples.{Baz}
+             defmodule Examples.AliasWithCurlyBrackets do
+               alias Examples.{Baz}
 
-  Baz
+               Baz
 
-  def parse_headers(_headers, headers1) do
-    headers1
-  end
+               def parse_headers(_headers, headers1) do
+                 headers1
+               end
 
-  def parse_params(%{"title" => _title}), do: nil
-  def parse_params(%{title: _title}), do: nil
-end
-""")
+               def parse_params(%{"title" => _title}), do: nil
+               def parse_params(%{title: _title}), do: nil
+             end
+             """)
   end
 
   test "safely prefix with _" do
@@ -55,7 +55,8 @@ end
   end
 
   test "prefix ignores map string keys" do
-    assert "%{\"bar\" => _bar}" == FixWarnings.Util.prefix_with_underscore("%{\"bar\" => _bar}", "bar")
+    assert "%{\"bar\" => _bar}" ==
+             FixWarnings.Util.prefix_with_underscore("%{\"bar\" => _bar}", "bar")
   end
 
   test "prefix ignores map atom keys" do
@@ -69,5 +70,4 @@ end
   test "safely prefix with mybar" do
     assert "mybar" == FixWarnings.Util.prefix_with_underscore("mybar", "bar")
   end
-
 end

--- a/test/fix_warnings_test.exs
+++ b/test/fix_warnings_test.exs
@@ -2,8 +2,6 @@ defmodule FixWarningsTest do
   use ExUnit.Case
   doctest FixWarnings
 
-  alias FixWarnings.Util
-
   test "basic test" do
     %{file: "test/test.log"}
     |> FixWarnings.changes()

--- a/test/fix_warnings_test.exs
+++ b/test/fix_warnings_test.exs
@@ -1,12 +1,20 @@
-require IEx
-
 defmodule FixWarningsTest do
   use ExUnit.Case
   doctest FixWarnings
 
   test "basic test" do
-    changes = FixWarnings.changes("test/test.log")
+    %{file: "test/test.log"}
+    |> FixWarnings.changes()
+    |> assert_changes
+  end
 
+  test "basic test for deprecated logs style (without function references)'" do
+    %{file: "test/test_deprecated.log"}
+    |> FixWarnings.changes()
+    |> assert_changes
+  end
+
+  defp assert_changes(changes) do
     assert String.trim(changes["examples/foo.ex"]) ==
              String.trim("""
              defmodule Examples.Bar do
@@ -26,7 +34,7 @@ defmodule FixWarningsTest do
   end
 
   test "edge-cases" do
-    changes = FixWarnings.changes("test/todo.log")
+    changes = FixWarnings.changes(%{file: "test/todo.log"})
 
     assert String.trim(changes["examples/todo.ex"]) ==
              String.trim("""

--- a/test/fix_warnings_test.exs
+++ b/test/fix_warnings_test.exs
@@ -2,6 +2,8 @@ defmodule FixWarningsTest do
   use ExUnit.Case
   doctest FixWarnings
 
+  alias FixWarnings.Util
+
   test "basic test" do
     %{file: "test/test.log"}
     |> FixWarnings.changes()
@@ -56,26 +58,5 @@ defmodule FixWarningsTest do
                def parse_params(%{title: _title}), do: nil
              end
              """)
-  end
-
-  test "safely prefix with _" do
-    assert "(_bar)" == FixWarnings.Util.prefix_with_underscore("(bar)", "bar")
-  end
-
-  test "prefix ignores map string keys" do
-    assert "%{\"bar\" => _bar}" ==
-             FixWarnings.Util.prefix_with_underscore("%{\"bar\" => _bar}", "bar")
-  end
-
-  test "prefix ignores map atom keys" do
-    assert "%{bar: _bar}" == FixWarnings.Util.prefix_with_underscore("%{bar: _bar}", "bar")
-  end
-
-  test "safely prefix with my_bar" do
-    assert "my_bar" == FixWarnings.Util.prefix_with_underscore("my_bar", "bar")
-  end
-
-  test "safely prefix with mybar" do
-    assert "mybar" == FixWarnings.Util.prefix_with_underscore("mybar", "bar")
   end
 end

--- a/test/test.log
+++ b/test/test.log
@@ -1,11 +1,12 @@
-warning: variable "unused_param" is unused
-  examples/foo.ex:9
+Compiling 1 file (.ex)
+warning: variable "unused_param" is unused  (if the variable is not meant to be used, prefix it with an underscore)
+  examples/foo.ex:9: M.f/2
 
-warning: variable "unused_param1" is unused
-  examples/foo.ex:13
+warning: variable "unused_param1" is unused  (if the variable is not meant to be used, prefix it with an underscore)
+  examples/foo.ex:13: M.f/2
 
-warning: variable "unused_param2" is unused
-  examples/foo.ex:13
+warning: variable "unused_param2" is unused  (if the variable is not meant to be used, prefix it with an underscore)
+  examples/foo.ex:13: M.f/2
 
 warning: unused alias Bar
   examples/foo.ex:6
@@ -13,3 +14,4 @@ warning: unused alias Bar
 warning: unused alias Bar
   examples/file_that_does_not_exist_eg_an_external_package.ex:6
 
+Generated fix_warnings app

--- a/test/test_deprecated.log
+++ b/test/test_deprecated.log
@@ -1,0 +1,15 @@
+warning: variable "unused_param" is unused
+  examples/foo.ex:9
+
+warning: variable "unused_param1" is unused
+  examples/foo.ex:13
+
+warning: variable "unused_param2" is unused
+  examples/foo.ex:13
+
+warning: unused alias Bar
+  examples/foo.ex:6
+
+warning: unused alias Bar
+  examples/file_that_does_not_exist_eg_an_external_package.ex:6
+

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -1,0 +1,16 @@
+defmodule UtilTest do
+  use ExUnit.Case
+  doctest FixWarnings.Util
+
+  alias FixWarnings.Util
+
+  describe "parse_source/1" do
+    test "parses path and line_number from source line" do
+      assert {"examples/foo.ex", 13} == Util.parse_source("  examples/foo.ex:13: M.f/2")
+    end
+
+    test "parses path and line_number from deprecated-style source line" do
+      assert {"examples/foo.ex", 13} == Util.parse_source("  examples/foo.ex:13")
+    end
+  end
+end

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -13,4 +13,27 @@ defmodule UtilTest do
       assert {"examples/foo.ex", 13} == Util.parse_source("  examples/foo.ex:13")
     end
   end
+
+  describe "prefix_with_underscore/2" do
+    test "safely prefixes with _" do
+      assert "(_bar)" == Util.prefix_with_underscore("(bar)", "bar")
+    end
+
+    test "ignores map string keys" do
+      assert "%{\"bar\" => _bar}" ==
+               Util.prefix_with_underscore("%{\"bar\" => _bar}", "bar")
+    end
+
+    test "ignores map atom keys" do
+      assert "%{bar: _bar}" == Util.prefix_with_underscore("%{bar: _bar}", "bar")
+    end
+
+    test "safely prefixs with my_bar" do
+      assert "my_bar" == Util.prefix_with_underscore("my_bar", "bar")
+    end
+
+    test "safely prefixs with mybar" do
+      assert "mybar" == Util.prefix_with_underscore("mybar", "bar")
+    end
+  end
 end


### PR DESCRIPTION
Hello, @hasclass!

In typical developer fashion, I came across your repo after having spent a bunch of time working on my own solution. Looked like it did the trick, but it was untouched for 6 years. Figured I'd give it a go, and discovered that it didn't support the modern format of `mix compile` output.

# What Changed?
* formatted the repo
* updated the deps
* updated the `Util` `@source_mapper` to support the new format
* added up-to-date `OptionParser` arguments (and some nice aliases)
* here's the exciting one: added support for direct input from the `mix compile` command!
* ate the dog food 😄 

and now...
```
$ mix compile --force --warnings-as-errors
Compiling 7 files (.ex)
Generated fix_warnings app
$ mix test
Compiling 7 files (.ex)
Generated fix_warnings app
warning: unused alias Util
  test/fix_warnings_test.exs:5

..........

Finished in 0.04 seconds (0.00s async, 0.04s sync)
10 tests, 0 failures
```

# Next?
I added some todos!